### PR TITLE
change "attrNames" to "attributes"

### DIFF
--- a/docs/credentials.mdx
+++ b/docs/credentials.mdx
@@ -61,7 +61,7 @@ const schema = await client.createSchema({
     schemaParameters: {
         name: "Employee Badge",
         version: "1.0",
-        attrNames: [
+        attributes: [
             "Name",
             "Role",
             "Email"
@@ -92,7 +92,7 @@ var credentialDefinition = await client.createCredentialDefinition({
     credentialDefinitionFromSchemaParameters: {
         name: "Hooli Employee Badge",
         version: "1.0",
-        attrNames: ["Name", "Role", "Email"],
+        attributes: ["Name", "Role", "Email"],
         supportRevocation: false,
         tag: "unique identifier"
     }


### PR DESCRIPTION
Hi from digit.ink—hope this PR is helpful to you. credentialDefinitionFromSchemaParameters() didn't work for me until I made this change (using service-clients@1.1.3102). I haven't tested for createSchema() but I'm assuming it's the same.